### PR TITLE
Tool for writing Clang compile_commands.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+compile_commands.json
 # Entries below this point are managed by Please (DO NOT EDIT)
 plz-out
 .plzconfig.local

--- a/.plzconfig
+++ b/.plzconfig
@@ -41,7 +41,7 @@ DefaultValue = --std=c++11 -g3 -pipe -DDEBUG -Wall -Werror
 
 [PluginConfig "default_ldflags"]
 ConfigKey = DefaultLdFlags
-DefaultValue =
+DefaultValue = -lpthread -ldl
 
 [PluginConfig "pkg_config_path"]
 ConfigKey = PkgConfigPath

--- a/compdb/BUILD
+++ b/compdb/BUILD
@@ -1,0 +1,17 @@
+cc_binary(
+    name = "compdb",
+    srcs = ["compdb.cc"],
+    cflags = ["-Icompdb/subprocess"],
+    deps = [
+        ":subprocess",
+    ],
+)
+
+github_repo(
+    name = "subprocess",
+    repo = "arun11299/cpp-subprocess",
+    revision = "v2.0",
+    hashes = ["4dd85ccdbf5c78dee8321dc3587c2c4970793abc394c4b9288debc8825b01571"],
+    strip_prefix = "cpp-subprocess-2.0",
+    build_file = "subprocess.build",
+)

--- a/compdb/BUILD
+++ b/compdb/BUILD
@@ -1,8 +1,12 @@
 cc_binary(
     name = "compdb",
     srcs = ["compdb.cc"],
-    cflags = ["-Icompdb/subprocess"],
+    cflags = [
+        "-Icompdb/subprocess",
+        "-Icompdb/json/single_include",
+    ],
     deps = [
+        ":json",
         ":subprocess",
     ],
 )
@@ -14,4 +18,12 @@ github_repo(
     hashes = ["4dd85ccdbf5c78dee8321dc3587c2c4970793abc394c4b9288debc8825b01571"],
     strip_prefix = "cpp-subprocess-2.0",
     build_file = "subprocess.build",
+)
+
+github_repo(
+    name = "json",
+    repo = "nlohmann/json",
+    revision = "v3.10.4",
+    hashes = ["83258a1aa68921b1d82ca3fcfeef04f27471d33cc0e51d516109d161916223f2"],
+    build_file = "json.build",
 )

--- a/compdb/README.md
+++ b/compdb/README.md
@@ -1,0 +1,20 @@
+JSON Compilation Database
+=========================
+
+Contains a small program to create a JSON compilation database file for the current project
+which can be read by Clang / libclang etc.
+
+See https://clang.llvm.org/docs/JSONCompilationDatabase.html for more information about
+the format.
+
+
+Limitations
+-----------
+
+At present it does not build any dependencies so the some completions may not
+work if they have dynamically generated inputs etc (similarly they will not
+work after a `plz clean` which we can't do much about). This will be fixed after a
+`plz build` of the relevant actions, after which all the dependencies will be present.
+
+If you're using a [remote execution](https://please.build/remote_builds.html) profile
+you may need to do `plz build --download` to enforce downloading particular outputs.

--- a/compdb/README.md
+++ b/compdb/README.md
@@ -7,6 +7,12 @@ which can be read by Clang / libclang etc.
 See https://clang.llvm.org/docs/JSONCompilationDatabase.html for more information about
 the format.
 
+You may find it convenient to add an alias in your project for it:
+```
+alias ["clangcompdb"]
+cmd = run ///cc//compdb
+desc = Generate Clang compile_commands.json file
+```
 
 Limitations
 -----------

--- a/compdb/compdb.cc
+++ b/compdb/compdb.cc
@@ -1,7 +1,57 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <fstream>
+
 #include "nlohmann/json.hpp"
 #include "subprocess.hpp"
 
+using namespace nlohmann;
+using namespace std;
 
 int main(int argc, const char* argv[]) {
+  // Obviously std::filesystem is quite a bit nicer but it's _relatively_ new (e.g. on the
+  // box I'm writing this, it doesn't seem to be available, even with --std=c++17).
+  // TODO(peterebden): This is not quite right, it always returns the current path, but we
+  //                   really want the repo root. Maybe we should be able to ask plz for it?
+  const auto path_max = pathconf(".", _PC_PATH_MAX);
+  char* buf = (char*)malloc(path_max);
+  if (!getcwd(buf, path_max)) {
+    return 1;
+  }
+  const string dir(buf);
+
+  auto obuf = subprocess::check_output({"plz", "query", "graph", "-c", "dbg"});
+  auto graph = json::parse(obuf.buf.begin(), obuf.buf.end());
+
+  auto out = json::array();
+  for (const auto& pkg : graph["packages"]) {
+    for (const auto& target : pkg["targets"]) {
+      // Checking the prefix is a pretty quick and dirty way of finding the targets
+      // we consider relevant. Maybe we should check labels as well.
+      if (target.contains("command") && target.contains("srcs") && target["srcs"].contains("srcs")) {
+        auto cmd = target["command"].get<string>();
+        if (cmd.rfind("$TOOLS_CC", 0) == 0) {  // no starts_with until C++20 :(
+          const auto idx = cmd.find(" && ");
+          if (idx != string::npos) {
+            cmd.resize(idx);
+            cmd.resize(cmd.find_last_not_of(" "));
+          }
+          for (const auto& src : target["srcs"]["srcs"]) {
+            json j = {
+              {"directory", dir},
+              {"command", cmd},
+              {"file", src},
+            };
+            out.emplace_back(j);
+          }
+        }
+      }
+    }
+  }
+  std::ofstream f;
+  f.open("compile_commands.json");
+  f << out.dump();
+  f.close();
   return 0;
 }

--- a/compdb/compdb.cc
+++ b/compdb/compdb.cc
@@ -1,0 +1,5 @@
+#include "subprocess.hpp"
+
+int main(int argc, const char* argv[]) {
+  return 0;
+}

--- a/compdb/compdb.cc
+++ b/compdb/compdb.cc
@@ -1,4 +1,6 @@
+#include "nlohmann/json.hpp"
 #include "subprocess.hpp"
+
 
 int main(int argc, const char* argv[]) {
   return 0;

--- a/compdb/json.build
+++ b/compdb/json.build
@@ -1,0 +1,5 @@
+cc_library(
+    name = "json",
+    hdrs = ["single_include/nlohmann/json.hpp"],
+    visibility = ["PUBLIC"],
+)

--- a/compdb/subprocess.build
+++ b/compdb/subprocess.build
@@ -1,0 +1,5 @@
+cc_library(
+    name = "subprocess",
+    hdrs = ["subprocess.hpp"],
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
Implements the suggestion in https://github.com/thought-machine/please/issues/2166 

This is a little fiddly in various ways; it should be _pretty_ good but there will be cases that can't be flawless (mostly since Please executes build actions in hermetic directories that it sets up specifically for them, and there isn't an identical path permanently existing on disk corresponding to it). Mostly interested in getting some feedback about whether this is useful (since I've never used this thing before I'm not sure what is best to do with it; I've looked at a few projects out there but got bogged down trying to get the first few working).

Have written it in C++; would be a bit more straightforward in Go or Python frankly but I don't want this project to have dependencies on random other languages (and it was sort of fun to do some again and find out how rusty I am at it).

This is efficient since it only makes a single call to `plz query graph` to extract all the info it needs. Requires https://github.com/thought-machine/please/pull/2168 though for some additional fields there.