### PR TITLE
Update config to not use `@self`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -49,7 +49,7 @@ DefaultValue =
 
 [PluginConfig "test_main"]
 ConfigKey = TestMain
-DefaultValue = @self//unittest-pp:main
+DefaultValue = //unittest-pp:main
 
 [PluginConfig "dsym_tool"]
 ConfigKey = DsymTool


### PR DESCRIPTION
Targets in plugins are now resolved relative to the subrepo by default, so `@self` has been deprecated.