### PR TITLE
feat: allow adding additional optional outs

### DIFF
--- a/build_defs/c.build_defs
+++ b/build_defs/c.build_defs
@@ -8,7 +8,7 @@ you must pay attention to interoperability when needed (e.g. 'extern "C"' and so
 """
 subinclude("///cc//build_defs:cc")
 
-def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[], out:str='',
+def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[], out:str='', optional_outs:list=[],
               visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
               linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[],
               includes:list=[], defines:list|dict=[], alwayslink:bool=False, labels:list=[]):
@@ -24,6 +24,7 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
       deps (list): Dependent rules.
       out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
                        begins with 'lib').
+      optional_outs (list): Name of optional outputs.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
       compiler_flags (list): Flags to pass to the compiler.
@@ -48,6 +49,7 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
         private_hdrs = private_hdrs,
         deps = deps,
         out = out,
+        optional_outs = optional_outs,
         visibility = visibility,
         test_only = test_only,
         compiler_flags = compiler_flags,
@@ -62,8 +64,8 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
     )
 
 
-def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, test_only:bool&testonly=False,
-             compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
+def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, optional_outs:list=[],
+             test_only:bool&testonly=False ,compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
              pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], defines:list|dict=[],
              alwayslink:bool=False, visibility:list=None, deps:list=[], labels:list=[]):
     """Generate a C object file from a single source.
@@ -79,6 +81,7 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
       private_hdrs (list): Header files that are available only to this rule and not exported to
                            dependent rules.
       out (str): Name of the output file. Defaults to name + .o.
+      optional_outs (list): Name of optional outputs.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
@@ -103,6 +106,7 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
         hdrs = hdrs,
         private_hdrs = private_hdrs,
         out = out,
+        optional_outs = optional_outs,
         deps = deps,
         visibility = visibility,
         test_only = test_only,
@@ -119,7 +123,8 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
 
 
 def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-        deps:list=[], out:str='', visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[], labels:list=[]):
+        deps:list=[], out:str='', visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[], labels:list=[],
+        optional_outs:list=[]):
     """Generates a C static library (.a).
 
     This is essentially just a collection of other c_library rules into a single archive.
@@ -139,6 +144,7 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
       test_only (bool): If True, is only available to other test rules.
       pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
+      optional_outs (list): Name of optional outputs.
 
     """
     return cc_static_library(
@@ -147,6 +153,7 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
         hdrs = hdrs,
         deps = deps,
         out = out,
+        optional_outs = optional_outs,
         visibility = visibility,
         test_only = test_only,
         compiler_flags = compiler_flags,
@@ -160,7 +167,7 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
 
 def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_flags:list&cflags&copts=[],
                     linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
-                    pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], labels:list=[]):
+                    pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], labels:list=[], optional_outs:list=[]):
     """Generates a C shared object (.so) with its dependencies linked in.
 
     Args:
@@ -177,12 +184,14 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
       pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
+      optional_outs (list): Name of optional outputs.
     """
     return cc_shared_object(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
         out = out,
+        optional_outs = optional_outs,
         deps = deps,
         visibility = visibility,
         test_only = test_only,
@@ -198,7 +207,8 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
 
 def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compiler_flags:list&cflags&copts=[],
              linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, pkg_config_libs:list=[],
-             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, includes:list=[], defines:list|dict=[], labels:list=[]):
+             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, includes:list=[], defines:list|dict=[], labels:list=[],
+             optional_outs:list=[]):
     """Builds a binary from a collection of C rules.
 
     Args:
@@ -219,12 +229,14 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
                              values are surrounded by quotes.
       test_only (bool): If True, this rule can only be used by tests.
       static (bool): If True, the binary will be linked statically.
+      optional_outs (list): Name of optional outputs.
     """
     return cc_binary(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
         private_hdrs = private_hdrs,
+        optional_outs = optional_outs,
         deps = deps,
         visibility = visibility,
         test_only = test_only,

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -15,7 +15,7 @@ _WHOLE_ARCHIVE = '-all_load' if CONFIG.OS == 'darwin' else '--whole-archive'
 _NO_WHOLE_ARCHIVE = '-noall_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
 
 
-def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[], out:str='',
+def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[], out:str='', optional_outs:list=[],
                visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
                linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[],
                defines:list|dict=[], alwayslink:bool=False, linkstatic:bool=False, _c=False,
@@ -32,6 +32,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
       deps (list): Dependent rules.
       out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
                        begins with 'lib').
+      optional_outs (list): Name of optional outputs.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
       compiler_flags (list): Flags to pass to the compiler.
@@ -144,7 +145,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
                 name=a_name,
                 srcs={'srcs': [src], 'hdrs': hdrs, 'priv': private_hdrs},
                 outs=[a_name + '.a'],
-                optional_outs=['*.gcno'],  # For coverage
+                optional_outs=['*.gcno']+optional_outs,  # For coverage
                 deps=deps if src in _interfaces else all_deps,
                 cmd=cmds,
                 building_description='Compiling...',
@@ -196,7 +197,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             name=name,
             tag='cc',
             srcs={'srcs': srcs, 'hdrs': hdrs, 'priv': private_hdrs},
-            optional_outs=['*.gcno'],  # For coverage
+            optional_outs=['*.gcno']+optional_outs,  # For coverage
             deps=deps if srcs == _interfaces else all_deps,
             outs=[out],
             cmd=cmds,
@@ -234,7 +235,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
     )
 
 
-def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, test_only:bool&testonly=False,
+def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, optional_outs:list=[], test_only:bool&testonly=False,
               compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[],
               includes:list=[], defines:list|dict=[], alwayslink:bool=False, _c=False, visibility:list=None, deps:list=[], labels:list=[]):
     """Generate a C or C++ object file from a single source.
@@ -250,6 +251,7 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
       private_hdrs (list): Header files that are available only to this rule and not exported to
                            dependent rules.
       out (str): Name of the output file. Defaults to name + .o.
+      optional_outs (list): Name of optional outputs.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
@@ -288,7 +290,7 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
         name=name,
         srcs={'srcs': [src], 'hdrs': hdrs, 'priv': private_hdrs},
         outs=[out or name + '.o'],
-        optional_outs=['*.gcno'],  # For coverage
+        optional_outs=['*.gcno']+optional_outs,  # For coverage
         deps=deps,
         cmd=cmds,
         building_description='Compiling...',
@@ -302,7 +304,7 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
     )
 
 
-def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], out:str='',
+def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], out:str='', optional_outs:list=[],
                       linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None,
                       test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[],_c=False, labels:list=[]):
     """Generates a C++ static library (.a).
@@ -320,6 +322,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
       deps (list): Dependent rules.
       out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
                        begins with 'lib').
+      optional_outs (list): Name of optional outputs.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
       pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
@@ -332,6 +335,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
             name = f'_{name}#lib' if srcs else f'_{name}#lib_hdrs',
             srcs = srcs,
             hdrs = hdrs,
+            optional_outs = optional_outs,
             compiler_flags = compiler_flags,
             linker_flags = linker_flags,
             deps = deps,
@@ -367,7 +371,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
     )
 
 
-def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_flags:list&cflags&copts=[],
+def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', optional_outs:list=[], compiler_flags:list&cflags&copts=[],
                      linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
                      pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], _c=False, labels:list=[]):
     """Generates a C++ shared object (.so) with its dependencies linked in.
@@ -378,6 +382,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
       hdrs (list): Header files. These will be made available to dependent rules, so the distinction
                    between srcs and hdrs is important.
       out (str): Name of the output .so. Defaults to lib<name>.so (or just <name>.so if name already begins with 'lib').
+      optional_outs (list): Name of optional outputs.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
       deps (list): Dependent rules.
@@ -397,6 +402,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             name = f'_{name}#lib',
             srcs = srcs,
             hdrs = hdrs,
+            optional_outs = optional_outs,
             compiler_flags = compiler_flags,
             linker_flags = linker_flags,
             deps = deps,
@@ -438,7 +444,7 @@ def cc_module(name:str, srcs:list=[], hdrs:list=[], interfaces:list=[], private_
               deps:list=[], visibility:list=None, test_only:bool&testonly=False,
               compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
               pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[],
-              defines:list|dict=[], alwayslink:bool=False, labels:list=[]):
+              defines:list|dict=[], alwayslink:bool=False, labels:list=[], optional_outs:list=[]):
     """Generate a C++ module.
 
     This is still experimental. Currently it has only been tested with clang; support for GCC
@@ -473,6 +479,7 @@ def cc_module(name:str, srcs:list=[], hdrs:list=[], interfaces:list=[], private_
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect.
       textual_hdrs (list): Also provided for Bazel compatibility. Effectively works the same as hdrs for now.
       labels (list): Labels to attach to this rule.
+      optional_outs (list): Name of optional outputs.
     """
     return cc_library(
         name = name,
@@ -480,6 +487,7 @@ def cc_module(name:str, srcs:list=[], hdrs:list=[], interfaces:list=[], private_
         hdrs = hdrs,
         _interfaces = interfaces,
         private_hdrs = private_hdrs,
+        optional_outs = optional_outs,
         deps = deps,
         visibility = visibility,
         test_only = test_only,
@@ -499,7 +507,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
               compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
               deps:list=[], visibility:list=None, pkg_config_libs:list=[], includes:list=[], defines:list|dict=[],
               pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, _c=False,
-              linkstatic:bool=False, labels:list=[]):
+              linkstatic:bool=False, labels:list=[], optional_outs:list=[]):
     """Builds a binary from a collection of C++ rules.
 
     Args:
@@ -523,6 +531,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
                          link roughly equivalently to their "mostly-static" mode.
       labels (list): Labels to attach to this rule.
+      optional_outs (list): Name of optional outputs.
     """
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
@@ -539,6 +548,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
             srcs=srcs,
             hdrs=hdrs,
             private_hdrs=private_hdrs,
+            optional_outs = optional_outs,
             deps=deps,
             pkg_config_libs=pkg_config_libs,
             pkg_config_cflags=pkg_config_cflags,


### PR DESCRIPTION
C and C++ rules have optional outs for coverage.

This pr allow to add more optional outs for specific usage.
For example c/c++ plugin of sonarqube produce additional outputs that can be kept using the new optional_outs c/c++ rules.

Replace https://github.com/thought-machine/please/pull/2519