### PR TITLE
Use `preloadsubincludes` instead of `preloadbuilddefs`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,8 +1,8 @@
 [please]
-version = >=16.12.1
+version = 16.22.1
 
 [parse]
-preloadbuilddefs = build_defs/cc.build_defs
+preloadsubincludes = //build_defs:cc
 
 [PluginDefinition]
 name = cc


### PR DESCRIPTION
I wasn't able to build the plugin on my machine:
```
test/modules/BUILD:2:15: error: Config has no such property CC
build_defs/cc.build_defs:384:8: error: Config has no such property CC
etc.
```
but I was able to with `preloadsubincludes`. Not 100% sure why that is, but IIRC we were moving away from using `preloadbuilddefs`.