### PR TITLE
Make -fPIC configurable  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ compile_commands.json
 # Entries below this point are managed by Please (DO NOT EDIT)
 plz-out
 .plzconfig.local
+
+.idea

--- a/.plzconfig
+++ b/.plzconfig
@@ -35,22 +35,22 @@ Inherit = true
 
 [PluginConfig "default_opt_cflags"]
 ConfigKey = DefaultOptCFlags
-DefaultValue = --std=c99 -O3 -pipe -DNDEBUG -Wall -Werror
+DefaultValue = --std=c99 -O3 -pipe -DNDEBUG -Wall -Werror -fPIC
 Inherit = true
 
 [PluginConfig "default_dbg_cflags"]
 ConfigKey = DefaultDbgCFlags
-DefaultValue = --std=c99 -g3 -pipe -DDEBUG -Wall -Werror
+DefaultValue = --std=c99 -g3 -pipe -DDEBUG -Wall -Werror -fPIC
 Inherit = true
 
 [PluginConfig "default_opt_cppflags"]
 ConfigKey = DefaultOptCppFlags
-DefaultValue = --std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror
+DefaultValue = --std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror -fPIC
 Inherit = true
 
 [PluginConfig "default_dbg_cppflags"]
 ConfigKey = DefaultDbgCppFlags
-DefaultValue = --std=c++11 -g3 -pipe -DDEBUG -Wall -Werror
+DefaultValue = --std=c++11 -g3 -pipe -DDEBUG -Wall -Werror -fPIC
 Inherit = true
 
 [PluginConfig "default_ldflags"]

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -673,7 +673,7 @@ def _default_cflags(c, dbg):
 
 def _build_flags(compiler_flags:list, pkg_config_libs:list, pkg_config_cflags:list, defines=None, c=False, dbg=False):
     """Builds flags that we'll pass to the compiler invocation."""
-    compiler_flags = [_default_cflags(c, dbg), '-fPIC'] + compiler_flags  # N.B. order is important!
+    compiler_flags = [_default_cflags(c, dbg)] + compiler_flags
     if defines:
         compiler_flags += ['-D' + define for define in defines]
 


### PR DESCRIPTION
Fixes #23 

This makes the PIC flag part of the default compiler flags for c and c++ rather than appending it to the default flags in the build def. 

NB: This is a breaking change. If you're compiler shared libraries with Please and override the default compiler flags, you will have to add this flag to your compiler flag list. 