### PR TITLE
GHA: switch to GCC 12 toolchain in `gcc` config

### DIFF
--- a/.plzconfig.gcc
+++ b/.plzconfig.gcc
@@ -1,6 +1,6 @@
 [plugin "cc"]
-cctool = gcc-10
-cpptool = g++-10
+cctool = gcc-12
+cpptool = g++-12
 ldtool = gold
 defaultdbgcppflags = --std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = --std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter


### PR DESCRIPTION
GCC 10 is no longer present on `macos-latest` - bump to GCC 12, which is available on both `ubuntu-latest` and `macos-latest`.

Fixes #33.