### PR TITLE
Added -Wno-suggest-override flags to tests.

### DIFF
--- a/unittest-pp/BUILD
+++ b/unittest-pp/BUILD
@@ -10,6 +10,7 @@ github_repo(
 cc_library(
     name = "main",
     srcs = ["unittest_main.cc"],
+    compiler_flags = ["-Wno-suggest-override"],
     visibility = ["PUBLIC"],
     deps = ["///unittest-pp/unittest_cpp//:unittest_cpp"],
 )

--- a/unittest-pp/unittest.build
+++ b/unittest-pp/unittest.build
@@ -6,5 +6,6 @@ cc_library(
     name = "unittest_cpp",
     srcs = glob(["UnitTest++/*.cpp", f"UnitTest++/{os}/*.cpp"]),
     hdrs = glob(["UnitTest++/*.h", f"UnitTest++/{os}/*.h"]),
+    compiler_flags = ["-Wno-suggest-override"],
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION

Workaround for #30.

This makes it possible to run tests in an environment where `-Werror=suggest-override` and `-Werror` may be set.
Ideally, unittest-cpp would handle this itself, but seeing as that project seems to be on indefinite hiatus, this will at least get the cc-rules themselves to work.

Do note that this is not a complete fix and only handles the issue with `suggest-override` however this appeared to be the only issue in my environment. Other breaking flags can be added as they are found.

It should also be noted that any source files that need to use `#include <UnitTest++/UnitTest++.h>` must still wrap the contents with 
```c++
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wsuggest-override"
#include <UnitTest++/UnitTest++.h>

/// Contents of test code file

#pragma GCC diagnostic pop
```
or equivalent.