### PR TITLE
Ensure source file is final argument passed to CC and CPP tools

### DIFF
--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -722,7 +722,7 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_f
     """Returns the commands needed for a cc_library rule."""
     dbg_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c, dbg=True)
     opt_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c)
-    cmd_template = '$TOOLS_CC -c -I . ${SRCS_SRCS} %s %s'
+    cmd_template = '$TOOLS_CC -c -I . %s %s ${SRCS_SRCS}'
     if archive:
         cmd_template += ' && "$TOOLS_ARCAT" ar -r && "$TOOLS_AR" s "$OUT"'
     cmds = {


### PR DESCRIPTION
GCC and Clang both expect to receive the source files being compiled as their final arguments - putting options after them may be an error depending on the semantics of the option. When generating CC and CPP tool commands, ensure `$SRCS_SRCS` (the source file) is the final argument.