### PR TITLE
Use the ar tool defined in the plugin configuration

### DIFF
--- a/build_defs/cc_embed_binary.build_defs
+++ b/build_defs/cc_embed_binary.build_defs
@@ -50,7 +50,7 @@ def cc_embed_binary(name:str, src:str, deps:list=[], visibility:list=None,
         test_only = test_only,
     )
 
-    tools = {'arcat': [CONFIG.ARCAT_TOOL], 'ar': [CONFIG.AR_TOOL]}
+    tools = {'arcat': [CONFIG.ARCAT_TOOL], 'ar': [CONFIG.CC.AR_TOOL]}
     if darwin:
         # OSX's ld doesn't support '--format binary', and this is the least fiddly
         # alternative. Requiring an additional tool is a bit suboptimal but probably


### PR DESCRIPTION
`CONFIG.AR_TOOL` is inherited from Please, but it was removed from the top-level configuration in Please v17. Instead use `CONFIG.CC.AR_TOOL`, the ar tool defined in this plugin.