### PR TITLE
Use the ld tool and flags defined in the plugin configuration

### DIFF
--- a/build_defs/cc_embed_binary.build_defs
+++ b/build_defs/cc_embed_binary.build_defs
@@ -64,8 +64,8 @@ def cc_embed_binary(name:str, src:str, deps:list=[], visibility:list=None,
         ])
         tools['asm'] = [CONFIG.CC.ASM_TOOL]
     else:
-        cmd = '$TOOLS_LD -r --format binary %s -o ${OUTS/.a/.o} $SRC && $TOOLS_ARCAT ar --srcs ${OUTS/.a/.o} && $TOOLS_AR s $OUTS' % CONFIG.DEFAULT_LDFLAGS
-        tools['ld'] = [CONFIG.LD_TOOL]
+        cmd = '$TOOLS_LD -r --format binary %s -o ${OUTS/.a/.o} $SRC && $TOOLS_ARCAT ar --srcs ${OUTS/.a/.o} && $TOOLS_AR s $OUTS' % CONFIG.CC.DEFAULT_LDFLAGS
+        tools['ld'] = [CONFIG.CC.LD_TOOL]
 
     lib_rule = build_rule(
         name = name,


### PR DESCRIPTION
`CONFIG.LD_TOOL` and `CONFIG.DEFAULT_LDFLAGS` are inherited from Please, but they were removed from the top-level configuration in Please v17. Instead use `CONFIG.CC.LD_TOOL` and `CONFIG.CC.DEFAULT_LDFLAGS`, the ld tool and its default flags that are defined in this plugin.