### PR TITLE
Use thought-machine/release-action instead of tatskaari/release-action

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -43,6 +43,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: tatskaari/release-action@master
+        uses: thought-machine/release-action@master
         with:
           release-files: plz-out/package


### PR DESCRIPTION
The two are identical (for now), but the go-rules and python-rules plugins use thought-machine/release-action so we ought to be consistent.

python-rules uses a tagged release of release-action, whereas go-rules uses whatever is currently on master - the latter seems more sensible for an action we control (and eliminates the busywork of bumping a version number every time we make a change to release-action).