### PR TITLE
Invoke please_cc in place of `{CC,CPP,LD}_TOOL`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -55,6 +55,12 @@ DefaultValue = ar
 Inherit = true
 Help = The path or build target for the archiver tool.
 
+[PluginConfig "please_cc_tool"]
+ConfigKey = PleaseCCTool
+DefaultValue = //tools:please_cc
+Help = The path or build target for the please_cc tool, an internal tool used by the build definitions to invoke C/C++ compilers and linkers with appropriate command line arguments.
+Inherit = true
+
 [PluginConfig "default_opt_cflags"]
 ConfigKey = DefaultOptCFlags
 DefaultValue = --std=c99 -O3 -pipe -DNDEBUG -Wall -Werror

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -722,7 +722,7 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_f
     """Returns the commands needed for a cc_library rule."""
     dbg_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c, dbg=True)
     opt_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c)
-    cmd_template = '$TOOLS_CC -c -I . %s %s ${SRCS_SRCS}'
+    cmd_template = '"$TOOLS_PLEASE_CC" cc "$TOOLS_CC" -c -I . %s %s ${SRCS_SRCS}'
     if archive:
         cmd_template += ' && "$TOOLS_ARCAT" ar -r && "$TOOLS_AR" s "$OUT"'
     cmds = {
@@ -732,6 +732,7 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_f
     if CONFIG.CC.COVERAGE:
         cmds['cover'] = cmd_template % (dbg_flags + _COVERAGE_FLAGS, extra_flags)
     return cmds, {
+        'please_cc': CONFIG.CC.PLEASE_CC_TOOL,
         'cc': [CONFIG.CC.CC_TOOL if c else CONFIG.CC.CPP_TOOL],
         'arcat': [CONFIG.ARCAT_TOOL if archive else None],
         'ar': [CONFIG.CC.AR_TOOL if archive else None],
@@ -743,14 +744,15 @@ def _binary_cmds(c, linker_flags, pkg_config_libs, extra_flags='', shared=False,
     dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=True, static=static)
     opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=False, static=static)
     cmds = {
-        'dbg': f'"$TOOLS_CC" -o "$OUT" {dbg_flags} {extra_flags}',
-        'opt': f'"$TOOLS_CC" -o "$OUT" {opt_flags} {extra_flags}',
+        'dbg': f'"$TOOLS_PLEASE_CC" cc "$TOOLS_CC" -o "$OUT" {dbg_flags} {extra_flags}',
+        'opt': f'"$TOOLS_PLEASE_CC" cc "$TOOLS_CC" -o "$OUT" {opt_flags} {extra_flags}',
     }
     tools = {
+        'please_cc': CONFIG.CC.PLEASE_CC_TOOL,
         'cc': (CONFIG.CC.CC_TOOL if c else CONFIG.CC.CPP_TOOL),
     }
     if CONFIG.CC.COVERAGE:
-        cmds['cover'] = f'"$TOOLS_CC" -o "$OUT" {dbg_flags} {extra_flags} {_COVERAGE_FLAGS}'
+        cmds['cover'] = f'"$TOOLS_PLEASE_CC" cc "$TOOLS_CC" -o "$OUT" {dbg_flags} {extra_flags} {_COVERAGE_FLAGS}'
 
     if CONFIG.CC.DSYM_TOOL:
         dbg = cmds['dbg']

--- a/build_defs/cc_embed_binary.build_defs
+++ b/build_defs/cc_embed_binary.build_defs
@@ -64,8 +64,11 @@ def cc_embed_binary(name:str, src:str, deps:list=[], visibility:list=None,
         ])
         tools['asm'] = [CONFIG.CC.ASM_TOOL]
     else:
-        cmd = '$TOOLS_LD -r --format binary %s -o ${OUTS/.a/.o} $SRC && $TOOLS_ARCAT ar --srcs ${OUTS/.a/.o} && $TOOLS_AR s $OUTS' % CONFIG.CC.DEFAULT_LDFLAGS
-        tools['ld'] = [CONFIG.CC.LD_TOOL]
+        cmd = '"$TOOLS_PLEASE_CC" ld "$TOOLS_LD" -r --format binary %s -o ${OUTS/.a/.o} $SRC && $TOOLS_ARCAT ar --srcs ${OUTS/.a/.o} && $TOOLS_AR s $OUTS' % CONFIG.CC.DEFAULT_LDFLAGS
+        tools = tools | {
+            "please_cc": CONFIG.CC.PLEASE_CC_TOOL,
+            "ld": CONFIG.CC.LD_TOOL,
+        }
 
     lib_rule = build_rule(
         name = name,

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,24 @@
+tools = {
+    "please_cc": {
+        "version": "0.1.1",
+        "hashes": {
+            "darwin_amd64": "b0f62ee03e2d685ef6b6e3859c61dc452ad4bd361986676e8b8bdac94ddd0ed3",
+            "darwin_arm64": "f62f9824ec5b3ec3b8f6d07968d1851994731d752a295994868c66e56bbe0966",
+            "freebsd_amd64": "47a6087bde791b66a77eab3ca27fa7db4215c0e8a0419822f38e70dc7c5740bb",
+            "linux_amd64": "a44fb9f24097cca844f69f344357fdeeacd94e40d3cf6914f78a48fe0f86b838",
+            "linux_arm64": "13638d7b03ca2204ca4d19075d6f66c04731d84e131cace35ea2b59ec38a0143",
+        },
+    },
+}
+
+for name, metadata in tools.items():
+    version = metadata["version"]
+    for a, h in metadata["hashes"].items():
+        native = f"{CONFIG.OS}_{CONFIG.ARCH}" == a
+        remote_file(
+            name = name if native else f"{name}_{a}",
+            binary = True,
+            hashes = [h],
+            url = f"https://github.com/please-build/cc-rules/releases/download/{name}-v{version}/{name}-{version}-{a}",
+            visibility = ["PUBLIC"] if native else None,
+        )


### PR DESCRIPTION
Download please_cc v0.1.1 and add a plugin configuration option for it so it can be referenced in `BUILD` files, then invoke please_cc wherever `CC_TOOL`, `CPP_TOOL` or `LD_TOOL` are currently invoked. This will allow the use of dynamically-selected compiler/linker options in the build definitions.