### PR TITLE
Use `-std` option to set C/C++ language standard

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -57,25 +57,25 @@ Help = The path or build target for the archiver tool.
 
 [PluginConfig "default_opt_cflags"]
 ConfigKey = DefaultOptCFlags
-DefaultValue = --std=c99 -O3 -pipe -DNDEBUG -Wall -Werror
+DefaultValue = -std=c99 -O3 -pipe -DNDEBUG -Wall -Werror
 Inherit = true
 Help = The default flags to pass to the C compiler when compiling a release build.
 
 [PluginConfig "default_dbg_cflags"]
 ConfigKey = DefaultDbgCFlags
-DefaultValue = --std=c99 -g3 -pipe -DDEBUG -Wall -Werror
+DefaultValue = -std=c99 -g3 -pipe -DDEBUG -Wall -Werror
 Inherit = true
 Help = The default flags to pass to the C compiler when compiling a debug build.
 
 [PluginConfig "default_opt_cppflags"]
 ConfigKey = DefaultOptCppFlags
-DefaultValue = --std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror
+DefaultValue = -std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror
 Inherit = true
 Help = The default flags to pass to the C++ compiler when compiling a release build.
 
 [PluginConfig "default_dbg_cppflags"]
 ConfigKey = DefaultDbgCppFlags
-DefaultValue = --std=c++11 -g3 -pipe -DDEBUG -Wall -Werror
+DefaultValue = -std=c++11 -g3 -pipe -DDEBUG -Wall -Werror
 Inherit = true
 Help = The default flags to pass to the C++ compiler when compiling a debug build.
 

--- a/.plzconfig.gha_macos_clang
+++ b/.plzconfig.gha_macos_clang
@@ -5,6 +5,6 @@ path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 cctool = clang
 cpptool = clang++
 ldtool = lld
-defaultdbgcppflags = --std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = --std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_macos_gcc
+++ b/.plzconfig.gha_macos_gcc
@@ -5,6 +5,6 @@ path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 cctool = gcc-12
 cpptool = g++-12
 ldtool = gold
-defaultdbgcppflags = --std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = --std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/.plzconfig.gha_ubuntu_clang
+++ b/.plzconfig.gha_ubuntu_clang
@@ -2,6 +2,6 @@
 cctool = clang
 cpptool = clang++
 ldtool = lld
-defaultdbgcppflags = --std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = --std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_ubuntu_gcc
+++ b/.plzconfig.gha_ubuntu_gcc
@@ -2,6 +2,6 @@
 cctool = gcc-12
 cpptool = g++-12
 ldtool = gold
-defaultdbgcppflags = --std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = --std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/README.md
+++ b/README.md
@@ -115,31 +115,31 @@ ARTool = ar
 ```
 
 ### DefaultOptCFlags
-Default flags used to compile C code. Defaults to `--std=c99 -O3 -pipe -DNDEBUG -Wall -Werror`. 
+Default flags used to compile C code. Defaults to `-std=c99 -O3 -pipe -DNDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultOptCFlags = --std=c99 -O4
+DefaultOptCFlags = -std=c99 -O4
 ```
 
 ### DefaultDbgCFlags 
-Default flags used to compile C code for debugging. Defaults to `--std=c99 -g3 -pipe -DDEBUG -Wall -Werror`.
+Default flags used to compile C code for debugging. Defaults to `-std=c99 -g3 -pipe -DDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultDbgCFlags = --std=c99 -O4
+DefaultDbgCFlags = -std=c99 -O4
 ```
 
 ### DefaultOptCppFlags
-Default flags used to compile C++ code. Defaults to `--std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror`.     
+Default flags used to compile C++ code. Defaults to `-std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultOptCFlags = --std=c99 -O4
+DefaultOptCFlags = -std=c99 -O4
 ```
 
 ### DefaultDbgCppFlags 
-Default flags used to compile C++ code for debugging. Defaults to `--std=c++11 -g3 -pipe -DDEBUG -Wall -Werror`.
+Default flags used to compile C++ code for debugging. Defaults to `-std=c++11 -g3 -pipe -DDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultDbgCFlags = --std=c99 -O4
+DefaultDbgCFlags = -std=c99 -O4
 ```
 
 ### DefaultLDFlags


### PR DESCRIPTION
There are repeated references in both the plugin configuration and documentation to a `--std` option that C/C++ compilers are not required to recognise (although in practice many of them quietly do) - the correct option name is `-std`.