### PR TITLE
Use optimisation level 3 everywhere

### DIFF
--- a/.plzconfig.gha_macos_clang
+++ b/.plzconfig.gha_macos_clang
@@ -6,5 +6,5 @@ cctool = clang
 cpptool = clang++
 ldtool = lld
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_macos_gcc
+++ b/.plzconfig.gha_macos_gcc
@@ -6,5 +6,5 @@ cctool = gcc-12
 cpptool = g++-12
 ldtool = gold
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/.plzconfig.gha_ubuntu_clang
+++ b/.plzconfig.gha_ubuntu_clang
@@ -3,5 +3,5 @@ cctool = clang
 cpptool = clang++
 ldtool = lld
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_ubuntu_gcc
+++ b/.plzconfig.gha_ubuntu_gcc
@@ -3,5 +3,5 @@ cctool = gcc-12
 cpptool = g++-12
 ldtool = gold
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
+defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/README.md
+++ b/README.md
@@ -118,28 +118,28 @@ ARTool = ar
 Default flags used to compile C code. Defaults to `-std=c99 -O3 -pipe -DNDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultOptCFlags = -std=c99 -O4
+DefaultOptCFlags = -std=c99 -O3
 ```
 
 ### DefaultDbgCFlags 
 Default flags used to compile C code for debugging. Defaults to `-std=c99 -g3 -pipe -DDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultDbgCFlags = -std=c99 -O4
+DefaultDbgCFlags = -std=c99 -O3
 ```
 
 ### DefaultOptCppFlags
 Default flags used to compile C++ code. Defaults to `-std=c++11 -O3 -pipe -DNDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultOptCFlags = -std=c99 -O4
+DefaultOptCFlags = -std=c99 -O3
 ```
 
 ### DefaultDbgCppFlags 
 Default flags used to compile C++ code for debugging. Defaults to `-std=c++11 -g3 -pipe -DDEBUG -Wall -Werror`.
 ```ini
 [Plugin "cc"]
-DefaultDbgCFlags = -std=c99 -O4
+DefaultDbgCFlags = -std=c99 -O3
 ```
 
 ### DefaultLDFlags


### PR DESCRIPTION
The default C/C++ compiler optimisation level is 3, but the GitHub runner profiles use 2 instead, and the examples in the README suggest setting the (currently meaningless) optimisation level 4. Standardise on 3 everywhere.