### PR TITLE
Remove `LDTool` plugin configuration option

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -43,12 +43,6 @@ DefaultValue = g++
 Inherit = true
 Help = The path or build target for the C++ compiler tool.
 
-[PluginConfig "ld_tool"]
-ConfigKey = LDTool
-DefaultValue = ld
-Inherit = true
-Help = The path or build target for the linker tool.
-
 [PluginConfig "ar_tool"]
 ConfigKey = ARTool
 DefaultValue = ar

--- a/.plzconfig.gha_macos_clang
+++ b/.plzconfig.gha_macos_clang
@@ -4,7 +4,6 @@ path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 [plugin "cc"]
 cctool = clang
 cpptool = clang++
-ldtool = lld
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_macos_gcc
+++ b/.plzconfig.gha_macos_gcc
@@ -4,7 +4,6 @@ path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
 [plugin "cc"]
 cctool = gcc-12
 cpptool = g++-12
-ldtool = gold
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/.plzconfig.gha_ubuntu_clang
+++ b/.plzconfig.gha_ubuntu_clang
@@ -1,7 +1,6 @@
 [plugin "cc"]
 cctool = clang
 cpptool = clang++
-ldtool = lld
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = true

--- a/.plzconfig.gha_ubuntu_gcc
+++ b/.plzconfig.gha_ubuntu_gcc
@@ -1,7 +1,6 @@
 [plugin "cc"]
 cctool = gcc-12
 cpptool = g++-12
-ldtool = gold
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 clangmodules = false

--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ The tool used by `cc_xxx()` build definitions to compile C++ code. Defaults to `
 CPPTool = clang++
 ```
 
-### LDTool
-The tool used to link C and C++ binaries and shared objects. Defaults to `ld`.
-```ini
-[Plugin "cc"]
-LDTool = ld
-```
-
 ### ARTool
 The tool used to manipulate `.a` archives. Defaults to `ar`. 
 ```ini


### PR DESCRIPTION
The linker was only ever called directly by `cc_embed_binary`, which was removed in #54.