### PR TITLE
CI: don't set `clangmodules` in GitHub Actions profiles

### DIFF
--- a/.plzconfig.gha_macos_clang
+++ b/.plzconfig.gha_macos_clang
@@ -6,4 +6,3 @@ cctool = clang
 cpptool = clang++
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-clangmodules = true

--- a/.plzconfig.gha_macos_gcc
+++ b/.plzconfig.gha_macos_gcc
@@ -6,4 +6,3 @@ cctool = gcc-12
 cpptool = g++-12
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-clangmodules = false

--- a/.plzconfig.gha_ubuntu_clang
+++ b/.plzconfig.gha_ubuntu_clang
@@ -3,4 +3,3 @@ cctool = clang
 cpptool = clang++
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-clangmodules = true

--- a/.plzconfig.gha_ubuntu_gcc
+++ b/.plzconfig.gha_ubuntu_gcc
@@ -3,4 +3,3 @@ cctool = gcc-12
 cpptool = g++-12
 defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
 defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-clangmodules = false


### PR DESCRIPTION
The `clangmodules` option went away some time ago (in fact I'm not sure it was ever honoured in the plugin version of the C/C++ rules...)