### PR TITLE
Ensure module declaration is the first statement in module test files

### DIFF
--- a/test/modules/f1.cc
+++ b/test/modules/f1.cc
@@ -1,5 +1,5 @@
-import q1;
 module f1;
+import q1;
 
 int f(int n) {
   if (n == 0) {

--- a/test/modules/q1.cc
+++ b/test/modules/q1.cc
@@ -1,5 +1,5 @@
-import f1;
 module q1;
+import f1;
 
 int q(int n) {
   if (n == 0) {


### PR DESCRIPTION
The `module` keyword should be the first token in a module file, and this is enforced as of Clang 17.