### PR TITLE
Implement a more robust CI testing strategy

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -1,40 +1,127 @@
-name: C & C++ rules
+name: Plugin
 on:
   - push
   - pull_request
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Run tests
-        run: ./pleasew test -e e2e --profile gha_${{ matrix.os }}_${{ matrix.compiler }} --log_file plz-out/log/test.log
-      - name: Run e2e test
-        run: ./pleasew test -i e2e --profile gha_${{ matrix.os }}_${{ matrix.compiler }} --log_file plz-out/log/e2e.log
-      - name: Archive logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-${{ matrix.os }}-${{ matrix.compiler }}
-          path: plz-out/log
+  test-cc-ubuntu-22-04:
+    name: ${{ matrix.name }}
+    uses: ./.github/workflows/plugin_test_cc.yaml
+    with:
+      runner: ubuntu-22.04
+      apt_packages: ${{ matrix.packages }}
+      plz_profile: ubuntu_${{ matrix.profile }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu
-          - macos
-        compiler:
-          - gcc
-          - clang
+        include:
+          - name: Clang 11
+            packages: clang-11
+            profile: clang-11
+          - name: Clang 12
+            packages: clang-12
+            profile: clang-12
+          - name: Clang 13
+            packages: clang-13
+            profile: clang-13
+  test-cc-ubuntu-24-04:
+    name: ${{ matrix.name }}
+    uses: ./.github/workflows/plugin_test_cc.yaml
+    with:
+      runner: ubuntu-24.04
+      apt_packages: ${{ matrix.packages }}
+      plz_profile: ubuntu_${{ matrix.profile }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Clang 14
+            packages: clang-14
+            profile: clang-14
+          - name: Clang 15
+            packages: clang-15
+            profile: clang-15
+          - name: Clang 16
+            packages: clang-16
+            profile: clang-16
+          - name: Clang 17
+            packages: clang-17
+            profile: clang-17
+          - name: Clang 18
+            packages: clang-18
+            profile: clang-18
+          - name: GCC 9
+            packages: gcc-9 g++-9
+            profile: gcc-9
+          - name: GCC 10
+            packages: gcc-10 g++-10
+            profile: gcc-10
+          - name: GCC 11
+            packages: gcc-11 g++-11
+            profile: gcc-11
+          - name: GCC 12
+            packages: gcc-12 g++-12
+            profile: gcc-12
+          - name: GCC 13
+            packages: gcc-13 g++-13
+            profile: gcc-13
+          - name: GCC 14
+            packages: gcc-14 g++-14
+            profile: gcc-14
+  test-cc-xcode-macos-14:
+    name: Xcode ${{ matrix.version }}
+    uses: ./.github/workflows/plugin_test_cc.yaml
+    with:
+      runner: macos-14
+      plz_profile: xcode-${{ matrix.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '15.0.1'
+          - '15.1'
+          - '15.2'
+          - '15.3'
+          - '15.4'
+  test-cc-xcode-macos-15:
+    name: Xcode ${{ matrix.version }}
+    uses: ./.github/workflows/plugin_test_cc.yaml
+    with:
+      runner: macos-15
+      plz_profile: xcode-${{ matrix.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '16.0'
+          - '16.1'
+          - '16.2'
+          - '16.3'
+          - '16.4'
+          - '26.0'
+  test-go:
+    name: Run Go tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out plugin code
+        uses: actions/checkout@v5
+      - name: Run Go tests
+        run: ./pleasew test -i test,go --keep_going --log_file plz-out/log/test.log
+      - name: Archive logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-go
+          path: plz-out/log
   release-tools:
+    name: Release please_cc
+    needs:
+      - test-go
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v5
       - name: Build please_cc
-        run: ./pleasew build --profile release -p -v notice //package:please_cc_release_files
+        run: ./pleasew build //package:please_cc_release_files
       - name: Release please_cc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,13 +132,17 @@ jobs:
           release-prefix: please_cc
           release-files: plz-out/package/please_cc
   release-plugin:
+    name: Release plugin
     needs:
-      - test
+      - test-cc-ubuntu-22-04
+      - test-cc-ubuntu-24-04
+      - test-cc-xcode-macos-14
+      - test-cc-xcode-macos-15
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v5
       - name: Release plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/plugin_test_cc.yaml
+++ b/.github/workflows/plugin_test_cc.yaml
@@ -1,0 +1,40 @@
+on:
+  workflow_call:
+    inputs:
+      # The GitHub runner type on which this workflow should run.
+      runner:
+        required: true
+        type: string
+      # The Please profile that should be loaded when testing the plugin.
+      plz_profile:
+        required: true
+        type: string
+      # A space-delimited list of Apt packages to install on the runner before testing the plugin.
+      # Only meaningful when the runner is Ubuntu-based.
+      apt_packages:
+        required: false
+        type: string
+jobs:
+  test:
+    name: Run C/C++ tests
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Install Apt packages
+        if: startsWith(inputs.runner, 'ubuntu-') && inputs.apt_packages
+        run: sudo apt-get install -y ${{ inputs.apt_packages }}
+      - name: Check out plugin code
+        uses: actions/checkout@v5
+      - name: Report compiler and linker versions
+        run: |
+          set -o pipefail
+          cc="$(grep -i '^CCTool =' .plzconfig.${{ inputs.plz_profile }} | sed -e 's/^CCTool = //')"
+          $cc -v -Wl,-v || true
+      - name: Run C/C++ tests
+        run: ./pleasew test -i test,cc --keep_going --log_file plz-out/log/test.log
+      - name: Archive logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ inputs.plz_profile }}
+          path: plz-out/log
+    env:
+      PLZ_CONFIG_PROFILE: ${{ inputs.plz_profile }}

--- a/.plzconfig.gha_macos_clang
+++ b/.plzconfig.gha_macos_clang
@@ -1,8 +1,0 @@
-[build]
-path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
-
-[plugin "cc"]
-cctool = clang
-cpptool = clang++
-defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter

--- a/.plzconfig.gha_macos_gcc
+++ b/.plzconfig.gha_macos_gcc
@@ -1,8 +1,0 @@
-[build]
-path = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
-
-[plugin "cc"]
-cctool = gcc-12
-cpptool = g++-12
-defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter

--- a/.plzconfig.gha_ubuntu_clang
+++ b/.plzconfig.gha_ubuntu_clang
@@ -1,5 +1,0 @@
-[plugin "cc"]
-cctool = clang
-cpptool = clang++
-defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter

--- a/.plzconfig.gha_ubuntu_gcc
+++ b/.plzconfig.gha_ubuntu_gcc
@@ -1,5 +1,0 @@
-[plugin "cc"]
-cctool = gcc-12
-cpptool = g++-12
-defaultdbgcppflags = -std=c++1z -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter
-defaultoptcppflags = -std=c++1z -O3 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter

--- a/.plzconfig.ubuntu_clang-11
+++ b/.plzconfig.ubuntu_clang-11
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-11
+CPPTool = clang++-11

--- a/.plzconfig.ubuntu_clang-12
+++ b/.plzconfig.ubuntu_clang-12
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-12
+CPPTool = clang++-12

--- a/.plzconfig.ubuntu_clang-13
+++ b/.plzconfig.ubuntu_clang-13
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-13
+CPPTool = clang++-13

--- a/.plzconfig.ubuntu_clang-14
+++ b/.plzconfig.ubuntu_clang-14
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-14
+CPPTool = clang++-14

--- a/.plzconfig.ubuntu_clang-15
+++ b/.plzconfig.ubuntu_clang-15
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-15
+CPPTool = clang++-15

--- a/.plzconfig.ubuntu_clang-16
+++ b/.plzconfig.ubuntu_clang-16
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-16
+CPPTool = clang++-16

--- a/.plzconfig.ubuntu_clang-17
+++ b/.plzconfig.ubuntu_clang-17
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-17
+CPPTool = clang++-17

--- a/.plzconfig.ubuntu_clang-18
+++ b/.plzconfig.ubuntu_clang-18
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-18
+CPPTool = clang++-18

--- a/.plzconfig.ubuntu_clang-19
+++ b/.plzconfig.ubuntu_clang-19
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-19
+CPPTool = clang++-19

--- a/.plzconfig.ubuntu_clang-20
+++ b/.plzconfig.ubuntu_clang-20
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = clang-20
+CPPTool = clang++-20

--- a/.plzconfig.ubuntu_gcc-10
+++ b/.plzconfig.ubuntu_gcc-10
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-10
+CPPTool = g++-10

--- a/.plzconfig.ubuntu_gcc-11
+++ b/.plzconfig.ubuntu_gcc-11
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-11
+CPPTool = g++-11

--- a/.plzconfig.ubuntu_gcc-12
+++ b/.plzconfig.ubuntu_gcc-12
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-12
+CPPTool = g++-12

--- a/.plzconfig.ubuntu_gcc-13
+++ b/.plzconfig.ubuntu_gcc-13
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-13
+CPPTool = g++-13

--- a/.plzconfig.ubuntu_gcc-14
+++ b/.plzconfig.ubuntu_gcc-14
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-14
+CPPTool = g++-14

--- a/.plzconfig.ubuntu_gcc-9
+++ b/.plzconfig.ubuntu_gcc-9
@@ -1,0 +1,3 @@
+[Plugin "cc"]
+CCTool = gcc-9
+CPPTool = g++-9

--- a/.plzconfig.xcode-15.0.1
+++ b/.plzconfig.xcode-15.0.1
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_15.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_15.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-15.1
+++ b/.plzconfig.xcode-15.1
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_15.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_15.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_15.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-15.2
+++ b/.plzconfig.xcode-15.2
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-15.3
+++ b/.plzconfig.xcode-15.3
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_15.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_15.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_15.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-15.4
+++ b/.plzconfig.xcode-15.4
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-16.0
+++ b/.plzconfig.xcode-16.0
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_16.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_16.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_16.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-16.1
+++ b/.plzconfig.xcode-16.1
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_16.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_16.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_16.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-16.2
+++ b/.plzconfig.xcode-16.2
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_16.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-16.3
+++ b/.plzconfig.xcode-16.3
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_16.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_16.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_16.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-16.4
+++ b/.plzconfig.xcode-16.4
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++

--- a/.plzconfig.xcode-26.0
+++ b/.plzconfig.xcode-26.0
@@ -1,0 +1,6 @@
+[BuildEnv]
+sdkroot = /Applications/Xcode_26.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+[Plugin "cc"]
+CCTool = /Applications/Xcode_26.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+CPPTool = /Applications/Xcode_26.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++


### PR DESCRIPTION
The current CI testing regime isn't very thorough (it basically tests against single, indeterminate versions of GCC and Clang on Ubuntu and Homebrew GCC and Homebrew Clang on macOS), which makes it difficult to identify failures against specific compiler toolchain versions without laborious manual testing. The dependencies between jobs are suboptimal too: there's no reason that failing C/C++ tests should block a release of please_cc (given that the tests use an existing release of please_cc).

Run the C/C++ tests against the following compiler matrix, and make the plugin release job contingent on all of them passing:

- GCC 9-14 on Ubuntu Noble
- Clang 11-13 on Ubuntu Jammy
- Clang 14-18 on Ubuntu Noble
- Xcode 15.0.1-15.4 on macOS 14
- Xcode 16.0-26.0 on macOS 15

The (please_cc) Go tests are architecture-agnostic, so just run them once independently of this matrix, and make the please_cc release job contingent on the Go tests passing.