### PR TITLE
Gate C++ module test behind `module_tests` feature flag

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -126,3 +126,10 @@ Help = The path or build target for dsymutil. If set, a .dSYM file containing sy
 ConfigKey = DefaultNamespace
 DefaultValue =
 Help = The default namespace in which to compile C++ code.
+
+[PluginConfig "feature_flags"]
+DefaultValue =
+Repeatable = true
+Optional = true
+Inherit = true
+Help = Flags to enable in-development features, or toggle breaking changes.

--- a/.plzconfig.ubuntu_clang-11
+++ b/.plzconfig.ubuntu_clang-11
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-11
 CPPTool = clang++-11
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-12
+++ b/.plzconfig.ubuntu_clang-12
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-12
 CPPTool = clang++-12
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-13
+++ b/.plzconfig.ubuntu_clang-13
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-13
 CPPTool = clang++-13
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-14
+++ b/.plzconfig.ubuntu_clang-14
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-14
 CPPTool = clang++-14
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-15
+++ b/.plzconfig.ubuntu_clang-15
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-15
 CPPTool = clang++-15
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-16
+++ b/.plzconfig.ubuntu_clang-16
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-16
 CPPTool = clang++-16
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-17
+++ b/.plzconfig.ubuntu_clang-17
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-17
 CPPTool = clang++-17
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-18
+++ b/.plzconfig.ubuntu_clang-18
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-18
 CPPTool = clang++-18
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-19
+++ b/.plzconfig.ubuntu_clang-19
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-19
 CPPTool = clang++-19
+FeatureFlags = module_tests

--- a/.plzconfig.ubuntu_clang-20
+++ b/.plzconfig.ubuntu_clang-20
@@ -1,3 +1,4 @@
 [Plugin "cc"]
 CCTool = clang-20
 CPPTool = clang++-20
+FeatureFlags = module_tests

--- a/test/modules/BUILD
+++ b/test/modules/BUILD
@@ -1,7 +1,8 @@
 subinclude("//build_defs:cc")
 
-# Currently only supported for Clang.
-if "clang" in CONFIG.CC.CPP_TOOL:
+# cc-rules currently only supports the C++ module implementation in (mainline) Clang. Opt into these
+# tests by enabling this plugin's "module_tests" feature flag.
+if "module_tests" in CONFIG.CC.FEATURE_FLAGS:
     cc_module(
         name = "hello",
         srcs = ["hello.cc"],


### PR DESCRIPTION
cc-rules currently only supports mainline Clang's implementation of C++ modules. Defining the test in `//test/modules` if the C++ compiler path contains the string `clang` causes the tests to also be defined (and therefore executed by `plz test`) against Apple Clang, which - to the best of my knowledge - doesn't feature a modules implementation that is compatible with mainline Clang's.

Gate the `//test/modules` test behind the `module_tests` feature flag, and enable it in the mainline Clang CI test profiles. This will prevent `plz build` or `plz test` from failing when Apple Clang is configured as the C++ compiler.