### PR TITLE
Only pass `--build-id=none` to linker when building ELF binaries

### DIFF
--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -728,13 +728,13 @@ def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bo
         # Ordering them would be ideal but we lack a convenient way of working that out from here.
         objs = ["-Wl,--start-group"] + objs + ["-Wl,--end-group"]
     # Don't add a .note.gnu.build-id section to ELF images. This improves the binary's determinism.
-    linker_flags += ["""'{{ gnuld || gold || lld ? "--build-id=none" }}'"""]
+    lflags = ["""'{{ gnuld || gold || lld ? "-Wl,--build-id=none" }}'"""]
     if shared:
         objs = ["-shared", f"-Wl,{_WHOLE_ARCHIVE}"] + objs + [f"-Wl,{_NO_WHOLE_ARCHIVE}"]
-    linker_flags = ["-Wl," + f.replace(" ", ",") for f in linker_flags] + _default_cflags(c, dbg)
+    lflags += ["-Wl," + f.replace(" ", ",") for f in linker_flags] + _default_cflags(c, dbg)
     if static:
-        linker_flags += ["-static"]
-    return objs + linker_flags + pkg_config_cmds
+        lflags += ["-static"]
+    return objs + lflags + pkg_config_cmds
 
 
 def _library_cmds(c:bool=False, compiler_flags:list=[], pkg_config_libs:list=[], pkg_config_cflags:list=[], extra_flags:list=[],

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -727,10 +727,8 @@ def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bo
         # support those flags; in many cases it will work without, so try that.
         # Ordering them would be ideal but we lack a convenient way of working that out from here.
         objs = ["-Wl,--start-group"] + objs + ["-Wl,--end-group"]
-    if CONFIG.OS == 'linux':
-        # This flag exists only in the GNU ld, where it improves determinism. OS detection is not ideal
-        # but there isn't much alternative.
-        linker_flags += ['--build-id=none']
+    # Don't add a .note.gnu.build-id section to ELF images. This improves the binary's determinism.
+    linker_flags += ["""'{{ gnuld || gold || lld ? "--build-id=none" }}'"""]
     if shared:
         objs = ["-shared", f"-Wl,{_WHOLE_ARCHIVE}"] + objs + [f"-Wl,{_NO_WHOLE_ARCHIVE}"]
     linker_flags = ["-Wl," + f.replace(" ", ",") for f in linker_flags] + _default_cflags(c, dbg)


### PR DESCRIPTION
The `.note.gnu.build-id` section is specific to the ELF binary format. Only call ELF linkers (i.e. GNU ld/gold, LLD) with `--build-id=none`, rather than assuming that all linkers will support this flag if the host OS is Linux (which will probably break cross-compilation, and needlessly omits the flag when running on FreeBSD).