### PR TITLE
CI: don't attempt to include release assets in plugin release

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -147,5 +147,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: thought-machine/release-action@master
-        with:
-          release-files: plz-out/package


### PR DESCRIPTION
There are no assets to include in releases of the plugin, so there's no need to specify a value of `release-files` for `release-action`.