### PR TITLE
Add static binary generation test

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -8,6 +8,10 @@ Stdlib = //third_party/go:std
 ImportPath = github.com/please-build/cc-rules
 RequireLicences = true
 
+[Plugin "e2e"]
+Target = //plugins:e2e
+DefaultPlugin = //test:cc-rules
+
 [PluginDefinition]
 name = cc
 

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+export_file(
+    name = "plzconfig",
+    src = ".plzconfig",
+    test_only = True,
+    visibility = [
+        "//test:cc-rules",
+    ],
+)

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -2,3 +2,9 @@ plugin_repo(
     name = "go",
     revision = "v1.24.0",
 )
+
+plugin_repo(
+    name = "e2e",
+    plugin = "plugin-integration-testing",
+    revision = "v1.1.0",
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,7 +1,23 @@
 # Test the way cc rules depend on one another; ideally we should be able to
 # pick up all transitive dependencies correctly but compile the .o files independently.
 
-subinclude("//build_defs:cc")
+subinclude(
+    "///e2e//build_defs:e2e",
+    "//build_defs:cc",
+)
+
+e2e_test_plugin(
+    name = "cc-rules",
+    srcs = [
+        "//build_defs:c",
+        "//build_defs:cc",
+        "//tools:please_cc",
+        "//:plzconfig",
+    ],
+    visibility = [
+        "//test/...",
+    ],
+)
 
 cc_library(
     name = "lib1",
@@ -78,4 +94,16 @@ cc_test(
     name = "cc_multisrc_test_2",
     srcs = ["cc_multisrc_test.cc"],
     deps = [":multisrc_lib_2"],
+)
+
+plugin_e2e_test(
+    name = "static_test",
+    repo = "static_repo",
+    test_cmd = [
+        "plz run //:static",
+        "file $(plz query outputs //:static) > file",
+    ],
+    expect_output_contains = {
+        "file": "statically linked",
+    },
 )

--- a/test/static_repo/.plzconfig
+++ b/test/static_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Plugin "cc"]
+Target = //plugins:cc

--- a/test/static_repo/BUILD_FILE
+++ b/test/static_repo/BUILD_FILE
@@ -1,0 +1,7 @@
+subinclude("///cc//build_defs:c")
+
+c_binary(
+    name = "static",
+    srcs = ["main.c"],
+    static = True,
+)

--- a/test/static_repo/main.c
+++ b/test/static_repo/main.c
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/test/static_repo/plugins/BUILD_FILE
+++ b/test/static_repo/plugins/BUILD_FILE
@@ -1,0 +1,4 @@
+plugin_repo(
+    name = "cc",
+    revision = "e2e",
+)


### PR DESCRIPTION
Add an end-to-end test to ensure that passing `static = True` to `c_binary` (and, by implication, `cc_binary`) does in fact generate a working, statically linked binary.