### PR TITLE
Add plugin configuration option to enable garbage collection

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -108,6 +108,13 @@ DefaultValue = -ldl
 Inherit = true
 Help = The default flags to pass to the linker.
 
+[PluginConfig "enable_gc"]
+ConfigKey = EnableGC
+Type = bool
+DefaultValue = false
+Inherit = true
+Help = If true, enables link-time garbage collection for binary outputs in release builds. This removes unused code and data, usually resulting in smaller file sizes.
+
 [PluginConfig "pkg_config_path"]
 ConfigKey = PkgConfigPath
 DefaultValue =

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -702,13 +702,32 @@ def _default_cflags(c:bool=False, dbg:bool=False):
 
 def _build_flags(compiler_flags:list=[], pkg_config_libs:list=[], pkg_config_cflags:list=[], defines:list=[], c:bool=False, dbg:bool=False):
     """Builds the list of flags that we'll pass to the compiler invocation."""
-    compiler_flags = _default_cflags(c, dbg) + ["-fPIC"] + compiler_flags  # N.B. order is important!
+    cflags = _default_cflags(c, dbg) + ["-fPIC"]
+
+    if CONFIG.CC.ENABLE_GC and not dbg:
+        cflags += [
+            # Place all functions and data (global variables, constants) into their own sections in the object code.
+            # These options are only meaningful when building ELF object code, but they're both treated as no-ops by all
+            # the compilers we support when building Mach-O object code, so (thankfully) there's no need to figure out
+            # whether to pass them based on the target architecture (which we don't necessarily know here).
+            "-fdata-sections",
+            "-ffunction-sections",
+            # -ffunction-sections causes sections to be emitted with unique names. Avoid doing this, if the compiler
+            # and linker both support it: it significantly increases the size of the ELF string table. This requires a
+            # linker that can handle repeated section names, which all reasonably modern versions of linkers that
+            # generate ELF code already do (e.g. GNU ld/gold >= 2.35).
+            """'{{ clang || aclang ? "-fno-unique-section-names" }}'""",
+        ]
+
+    # Now append the compiler flags we were given, which allows the plugin defaults (and whatever else we set above) to
+    # be overridden (i.e. by the user).
+    cflags += compiler_flags
     if defines:
-        compiler_flags += ['-D' + define for define in defines]
+        cflags += ['-D' + define for define in defines]
 
     pkg_config_cmds = [f"`pkg-config --cflags {x}`" for x in (pkg_config_cflags + pkg_config_libs)]
 
-    return compiler_flags + pkg_config_cmds
+    return cflags + pkg_config_cmds
 
 
 def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bool=False, alwayslink:list=[], c:bool=False, dbg:bool=False,
@@ -763,8 +782,14 @@ def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bo
 
     # Don't add a .note.gnu.build-id section to ELF images. This improves the binary's determinism.
     lflags = ["""'{{ gnuld || gold || lld ? "-Wl,--build-id=none" }}'"""]
+
+    if CONFIG.CC.ENABLE_GC and not dbg:
+        lflags += ["""'{{ ld64 || appleld ? "-Wl,-dead_strip" : "-Wl,--gc-sections" }}'"""]
+
     lflags += [_escape_linker_flag(f) for f in linker_flags]
+
     lflags += _default_cflags(c, dbg)
+
     if static:
         lflags += ["-static"]
 


### PR DESCRIPTION
Link-time garbage collection can significantly reduce the size of binaries. Simplify its use by adding a plugin configuration option, `EnableGC`, that tells the compiler to place functions and data in their own sections, then tells the linker to discard sections that are never referenced. Because link-time GC requires both compiler and linker options, it's not really practical to allow it to be configured at the individual target level, hence this being a plugin configuration option rather than new parameters for `cc_library`, `cc_shared_object`, `cc_binary` and `cc_test`.

Support for link-time GC has existed in GCC, Clang and Apple Clang since at least the minimum versions of those compilers supported by this plugin (although only Clang and Apple Clang support the option that causes section names to be reused; this also requires an ELF linker that is recent enough to support repeated section names, which is again the case for the minimum versions of GNU ld, gold and LLD that this plugin supports).