### PR TITLE
Strip binaries and shared objects by default

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -138,6 +138,13 @@ ConfigKey = DefaultNamespace
 DefaultValue =
 Help = The default namespace in which to compile C++ code.
 
+[PluginConfig "default_strip"]
+ConfigKey = DefaultStrip
+Type = bool
+Inherit = true
+DefaultValue = true
+Help = If true, strip all symbol information from non-test binary outputs in release builds by default.
+
 [PluginConfig "feature_flags"]
 DefaultValue =
 Repeatable = true

--- a/build_defs/c.build_defs
+++ b/build_defs/c.build_defs
@@ -166,8 +166,9 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
 
 
 def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_flags:list&cflags&copts=[],
-                    linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
-                    pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], labels:list=[], optional_outs:list=[]):
+                    linker_flags:list&ldflags&linkopts=[], strip:bool=CONFIG.CC.DEFAULT_STRIP, deps:list=[],
+                    visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[],
+                    pkg_config_cflags:list=[], includes:list=[], labels:list=[], optional_outs:list=[]):
     """Generates a C shared object (.so) with its dependencies linked in.
 
     Args:
@@ -178,6 +179,8 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
       out (str): Name of the output .so. Defaults to name + .so.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
+      strip (bool): If true, strip all symbol information from the output in release builds. Defaults
+                    to the value of the plugin's DefaultStrip configuration option.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
@@ -197,6 +200,7 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
         test_only = test_only,
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
+        strip = strip,
         pkg_config_libs = pkg_config_libs,
         pkg_config_cflags = pkg_config_cflags,
         includes = includes,
@@ -206,9 +210,9 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
 
 
 def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compiler_flags:list&cflags&copts=[],
-             linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, pkg_config_libs:list=[],
-             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, includes:list=[], defines:list|dict=[], labels:list=[],
-             optional_outs:list=[]):
+             linker_flags:list&ldflags&linkopts=[], strip:bool=CONFIG.CC.DEFAULT_STRIP, deps:list=[], visibility:list=None,
+             pkg_config_libs:list=[], pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False,
+             includes:list=[], defines:list|dict=[], labels:list=[], optional_outs:list=[]):
     """Builds a binary from a collection of C rules.
 
     Args:
@@ -219,6 +223,8 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
                            dependent rules.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
+      strip (bool): If true, strip all symbol information from the output in release builds. Defaults
+                    to the value of the plugin's DefaultStrip configuration option.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
@@ -242,6 +248,7 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
         test_only = test_only,
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
+        strip = strip,
         pkg_config_libs = pkg_config_libs,
         pkg_config_cflags = pkg_config_cflags,
         includes = includes,

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -388,8 +388,9 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
 
 
 def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', optional_outs:list=[], compiler_flags:list&cflags&copts=[],
-                     linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
-                     pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], _c=False, labels:list=[]):
+                     linker_flags:list&ldflags&linkopts=[], strip:bool=CONFIG.CC.DEFAULT_STRIP, deps:list=[], visibility:list=None,
+                     test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], _c=False,
+                     labels:list=[]):
     """Generates a C++ shared object (.so) with its dependencies linked in.
 
     Args:
@@ -401,6 +402,8 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', optional_
       optional_outs (list): Name of optional outputs.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
+      strip (bool): If true, strip all symbol information from the output in release builds. Defaults
+                    to the value of the plugin's DefaultStrip configuration option.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
@@ -433,7 +436,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', optional_
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,
         }
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, shared=True)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, strip, shared=True, test=False)
     if not out:
         out = f'{name}.so' if name.startswith('lib') else f'lib{name}.so'
     return build_rule(
@@ -451,7 +454,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', optional_
         tools=tools,
         test_only=test_only,
         requires=['cc', 'cc_hdrs'],
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, shared=True) if deps else None,
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, strip, shared=True, test=False) if deps else None,
         labels=labels,
     )
 
@@ -520,7 +523,7 @@ def cc_module(name:str, srcs:list=[], hdrs:list=[], interfaces:list=[], private_
 
 
 def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
-              compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
+              compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[], strip:bool=CONFIG.CC.DEFAULT_STRIP,
               deps:list=[], visibility:list=None, pkg_config_libs:list=[], includes:list=[], defines:list|dict=[],
               pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, _c=False,
               linkstatic:bool=False, labels:list=[], optional_outs:list=[]):
@@ -534,6 +537,8 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
                            dependent rules.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
+      strip (bool): If true, strip all symbol information from the output in release builds. Defaults
+                    to the value of the plugin's DefaultStrip configuration option.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
@@ -555,7 +560,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
         linker_flags += CONFIG.CC.DEFAULT_LDFLAGS
     if static:
         linker_flags += ['-static']
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, static=static)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, strip, static=static, test=False)
     if srcs:
         if static:
             compiler_flags += ["-static", """'{{ gcc ? "-static-libgcc" }}'"""]
@@ -587,7 +592,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
         output_is_complete=True,
         requires=['cc'],
         tools=tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, strip, test=False),
         test_only=test_only,
         optional_outs = [f"{name}.dSYM"] if CONFIG.CC.DSYM_TOOL else [],
         labels=labels,
@@ -636,7 +641,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
         linker_flags += CONFIG.CC.DEFAULT_LDFLAGS
     if CONFIG.CC.TEST_MAIN and not _c:
         deps += [CONFIG.CC.TEST_MAIN]
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, test=True)
 
     if srcs:
         lib_rule = cc_library(
@@ -683,7 +688,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
         labels=labels,
         tools=tools,
         test_tools = test_tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, test=True),
         flaky=flaky,
         test_outputs=test_outputs,
         test_timeout=timeout,
@@ -730,8 +735,8 @@ def _build_flags(compiler_flags:list=[], pkg_config_libs:list=[], pkg_config_cfl
     return cflags + pkg_config_cmds
 
 
-def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bool=False, alwayslink:list=[], c:bool=False, dbg:bool=False,
-                        static:bool=False):
+def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bool=False, alwayslink:list=[], strip:bool=None,
+                        c:bool=False, dbg:bool=False, static:bool=False, test:bool=False):
     """Builds the list of flags that we'll pass to the linker invocation."""
     pkg_config_cmds = [f"`pkg-config --libs {x}`" for x in pkg_config_libs]
 
@@ -783,8 +788,11 @@ def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bo
     # Don't add a .note.gnu.build-id section to ELF images. This improves the binary's determinism.
     lflags = ["""'{{ gnuld || gold || lld ? "-Wl,--build-id=none" }}'"""]
 
-    if CONFIG.CC.ENABLE_GC and not dbg:
-        lflags += ["""'{{ ld64 || appleld ? "-Wl,-dead_strip" : "-Wl,--gc-sections" }}'"""]
+    if not dbg:
+        if CONFIG.CC.ENABLE_GC:
+            lflags += ["""'{{ ld64 || appleld ? "-Wl,-dead_strip" : "-Wl,--gc-sections" }}'"""]
+        if strip and not test:
+            lflags += ["""'{{ ld64 || appleld ? ["-Wl,-S", "-Wl,-x"] : "-Wl,--strip-all" }}'"""]
 
     lflags += [_escape_linker_flag(f) for f in linker_flags]
 
@@ -838,11 +846,11 @@ def _library_cmds(c:bool=False, compiler_flags:list=[], pkg_config_libs:list=[],
     }
 
 
-def _binary_cmds(c:bool=False, linker_flags:list=[], pkg_config_libs:list=[], extra_flags:list=[], shared:bool=False, alwayslink:list=[],
-                 static:bool=False):
+def _binary_cmds(c:bool=False, linker_flags:list=[], pkg_config_libs:list=[], strip:bool=None, extra_flags:list=[],
+                 shared:bool=False, alwayslink:list=[], static:bool=False, test:bool=False):
     """Returns the commands needed for a cc_binary, cc_test or cc_shared_object rule."""
-    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=True, static=static)
-    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=False, static=static)
+    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, strip, c=c, dbg=True, static=static, test=test)
+    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, strip, c=c, dbg=False, static=static, test=test)
     cmd_template = '"$TOOLS_PLEASE_CC" cc "$TOOLS_CC" -o "$OUT" %s'
     cmds = {
         'dbg': cmd_template % ' '.join(dbg_flags + extra_flags),
@@ -903,7 +911,8 @@ def _library_transitive_labels(c:bool=False, compiler_flags:list=[], pkg_config_
     return apply_transitive_labels
 
 
-def _binary_transitive_labels(c:bool=False, linker_flags:list=[], pkg_config_libs:list=[], shared:bool=False):
+def _binary_transitive_labels(c:bool=False, linker_flags:list=[], pkg_config_libs:list=[], strip:bool=None, shared:bool=False,
+                              test:bool=False):
     """Applies commands from transitive labels to a cc_binary, cc_test or cc_shared_object rule."""
     def apply_transitive_labels(name):
         labels = get_labels(name, 'cc:')
@@ -917,7 +926,7 @@ def _binary_transitive_labels(c:bool=False, linker_flags:list=[], pkg_config_lib
         # Probably a little optimistic to check this (most binaries are likely to have *some*
         # kind of linker flags to apply), but we might as well.
         if flags or alwayslink:
-            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, flags, shared, alwayslink)
+            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, strip, flags, shared, alwayslink, test=test)
             for k, v in cmds.items():
                 set_command(name, k, v)
     return apply_transitive_labels

--- a/test/strip/BUILD
+++ b/test/strip/BUILD
@@ -1,0 +1,58 @@
+subinclude(
+    "//build_defs:c",
+    "//build_defs:cc",
+)
+
+binary_linker_flags = [
+    "-L" + package_name(),
+    "-rpath '%s'" % ("@executable_path" if CONFIG.OS == "darwin" else "$ORIGIN"),
+]
+
+data = {}
+
+for strip in [True, False]:
+    stripped = "stripped" if strip else "unstripped"
+
+    data[f"c_so_{stripped}"] = c_shared_object(
+        name = f"c_so_{stripped}",
+        srcs = ["so.c"],
+        out = f"libc_so_{stripped}.so",
+        hdrs = ["so.h"],
+        linker_flags = [f"-install_name @rpath/lib_c_{stripped}.so"] if CONFIG.OS == "darwin" else [],
+        strip = strip,
+    )
+    data[f"c_binary_{stripped}"] = c_binary(
+        name = f"c_binary_{stripped}",
+        srcs = ["binary.c"],
+        hdrs = ["so.h"],
+        linker_flags = binary_linker_flags + [f"-lc_so_{stripped}"],
+        strip = strip,
+        deps = [f":c_so_{stripped}"],
+    )
+    data[f"cc_so_{stripped}"] = cc_shared_object(
+        name = f"cc_so_{stripped}",
+        srcs = ["so.cpp"],
+        out = f"libcc_so_{stripped}.so",
+        hdrs = ["so.hpp"],
+        linker_flags = [f"-install_name @rpath/lib_cc_{stripped}.so"] if CONFIG.OS == "darwin" else [],
+        strip = strip,
+    )
+    data[f"cc_binary_{stripped}"] = cc_binary(
+        name = f"cc_binary_{stripped}",
+        srcs = ["binary.cpp"],
+        linker_flags = binary_linker_flags + [f"-lcc_so_{stripped}"],
+        strip = strip,
+        deps = [f":cc_so_{stripped}"],
+    )
+
+gentest(
+    name = "strip_test",
+    test_cmd = [
+        "for i in $DATA_C_BINARY_STRIPPED $DATA_CC_BINARY_STRIPPED $DATA_C_BINARY_UNSTRIPPED $DATA_CC_BINARY_UNSTRIPPED; do test $($i) = 42; done",
+        "for i in $DATA_C_SO_UNSTRIPPED $DATA_C_BINARY_UNSTRIPPED $DATA_CC_BINARY_UNSTRIPPED; do file $i | grep -q 'not stripped'; done",
+        "for i in $DATA_C_SO_STRIPPED $DATA_C_BINARY_STRIPPED $DATA_CC_BINARY_STRIPPED; do file $i | grep -q ', stripped'; done",
+    ],
+    data = data,
+    exit_on_error = True,
+    no_test_output = True,
+)

--- a/test/strip/binary.c
+++ b/test/strip/binary.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#include "so.h"
+
+int main() {
+    printf("%d\n", answer());
+}

--- a/test/strip/binary.cpp
+++ b/test/strip/binary.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#include "so.hpp"
+
+int main() {
+    Answer a;
+    std::cout << a.answer() << std::endl;
+}

--- a/test/strip/so.c
+++ b/test/strip/so.c
@@ -1,0 +1,5 @@
+#include "so.h"
+
+int answer() {
+    return 42;
+}

--- a/test/strip/so.cpp
+++ b/test/strip/so.cpp
@@ -1,0 +1,5 @@
+#include "so.hpp"
+
+int Answer::answer() {
+    return 42;
+}

--- a/test/strip/so.h
+++ b/test/strip/so.h
@@ -1,0 +1,7 @@
+#ifndef __SO_H__
+
+#define __SO_H__
+
+int answer();
+
+#endif

--- a/test/strip/so.hpp
+++ b/test/strip/so.hpp
@@ -1,0 +1,10 @@
+#ifndef __SO_HPP__
+
+#define __SO_HPP__
+
+class Answer {
+    public:
+        int answer();
+};
+
+#endif


### PR DESCRIPTION
When building in release mode (i.e. `-c opt`), strip the outputs of `cc_binary` and `cc_shared_object` (and their C equivalents). Don't bother stripping test binaries - they're not intended to be used outside of a repo, so there's little benefit in doing so.