### PR TITLE
Rename `EnableGC` configuration option to `LdGarbageCollection`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -108,8 +108,8 @@ DefaultValue = -ldl
 Inherit = true
 Help = The default flags to pass to the linker.
 
-[PluginConfig "enable_gc"]
-ConfigKey = EnableGC
+[PluginConfig "ld_garbage_collection"]
+ConfigKey = LdGarbageCollection
 Type = bool
 DefaultValue = false
 Inherit = true

--- a/build_defs/cc.build_defs
+++ b/build_defs/cc.build_defs
@@ -709,7 +709,7 @@ def _build_flags(compiler_flags:list=[], pkg_config_libs:list=[], pkg_config_cfl
     """Builds the list of flags that we'll pass to the compiler invocation."""
     cflags = _default_cflags(c, dbg) + ["-fPIC"]
 
-    if CONFIG.CC.ENABLE_GC and not dbg:
+    if CONFIG.CC.LD_GARBAGE_COLLECTION and not dbg:
         cflags += [
             # Place all functions and data (global variables, constants) into their own sections in the object code.
             # These options are only meaningful when building ELF object code, but they're both treated as no-ops by all
@@ -789,7 +789,7 @@ def _binary_build_flags(linker_flags:list=[], pkg_config_libs:list=[], shared:bo
     lflags = ["""'{{ gnuld || gold || lld ? "-Wl,--build-id=none" }}'"""]
 
     if not dbg:
-        if CONFIG.CC.ENABLE_GC:
+        if CONFIG.CC.LD_GARBAGE_COLLECTION:
             lflags += ["""'{{ ld64 || appleld ? "-Wl,-dead_strip" : "-Wl,--gc-sections" }}'"""]
         if strip and not test:
             lflags += ["""'{{ ld64 || appleld ? ["-Wl,-S", "-Wl,-x"] : "-Wl,--strip-all" }}'"""]


### PR DESCRIPTION
Annoyingly, the term "link-time garbage collection" overloads the much more widely-used (and widely-understood) term "garbage collection". Make it clearer that the `EnableGC` option specifically refers to actions taken during linking by renaming it to `LdGarbageCollection`.