### PR TITLE
Remove `//build_defs:cc_embed_binary`

### DIFF
--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -18,9 +18,3 @@ filegroup(
     srcs = ["c.build_defs"],
     visibility = ["PUBLIC"],
 )
-
-filegroup(
-    name = "cc_embed_binary",
-    srcs = ["cc_embed_binary.build_defs"],
-    visibility = ["PUBLIC"],
-)


### PR DESCRIPTION
The build definition file itself was deleted in #54, but the build target for that file has lingered ever since - remove that too.