### PR TITLE
CI: run all C/C++ tests in C/C++ matrix

### DIFF
--- a/.github/workflows/plugin_test_cc.yaml
+++ b/.github/workflows/plugin_test_cc.yaml
@@ -1,17 +1,16 @@
 on:
   workflow_call:
     inputs:
-      # The GitHub runner type on which this workflow should run.
       runner:
+        description: "The GitHub runner type on which this workflow should run."
         required: true
         type: string
-      # The Please profile that should be loaded when testing the plugin.
       plz_profile:
+        description: "The Please profile that should be loaded when testing the plugin."
         required: true
         type: string
-      # A space-delimited list of Apt packages to install on the runner before testing the plugin.
-      # Only meaningful when the runner is Ubuntu-based.
       apt_packages:
+        description: "A space-delimited list of Apt packages to install on the runner before testing the plugin. Only meaningful when the runner is Ubuntu-based."
         required: false
         type: string
 jobs:
@@ -30,7 +29,7 @@ jobs:
           cc="$(grep -i '^CCTool =' .plzconfig.${{ inputs.plz_profile }} | sed -e 's/^CCTool = //')"
           $cc -v -Wl,-v || true
       - name: Run C/C++ tests
-        run: ./pleasew test -i test,cc --keep_going --log_file plz-out/log/test.log
+        run: ./pleasew test -e test,go --keep_going --log_file plz-out/log/test.log
       - name: Archive logs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The union of `plz test -i test,cc` and `plz test -i test,go` isn't the set of tests in the repo: it excludes the `//test:static_test` e2e test and the `//test/strip:strip_test` and `//test/binary:cc_binary_test` `gentest`s. Consider the set of C/C++ tests to be the inversion of the set of tests triggered by `plz test -i test,go` (in other words, `plz test -e test,go`) so that these three tests are correctly considered to be C/C++ tests.