### PR TITLE
Use generic default C/C++ tool names

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -30,13 +30,13 @@ Help = The path or build target for the C coverage analysis tool.
 
 [PluginConfig "cc_tool"]
 ConfigKey = CCTool
-DefaultValue = gcc
+DefaultValue = cc
 Inherit = true
 Help = The path or build target for the C compiler tool.
 
 [PluginConfig "cpp_tool"]
 ConfigKey = CPPTool
-DefaultValue = g++
+DefaultValue = c++
 Inherit = true
 Help = The path or build target for the C++ compiler tool.
 


### PR DESCRIPTION
Most systems install their default C and C++ compilers to `cc` and `c++` respectively in a directory in `PATH`. Use these compilers as the default C and C++ tools, rather than assuming `gcc` and `g++` are present in `PATH` (this is fudged on macOS, where `/usr/bin/gcc` and `/usr/bin/g++` are actually Apple Clang, and doesn't hold at all on FreeBSD).